### PR TITLE
add missed isNull check in createActions

### DIFF
--- a/src/__tests__/createActions-test.js
+++ b/src/__tests__/createActions-test.js
@@ -120,6 +120,31 @@ describe('createActions', () => {
     });
   });
 
+  it('should use the identity if the payload creator is null in array form', () => {
+    const { action1, action2 } = createActions({
+      ACTION_1: [
+        null,
+        meta1 => ({ meta1 })
+      ],
+      ACTION_2: [
+        null,
+        ({ value }) => ({ meta2: value })
+      ]
+    });
+
+    expect(action1(1)).to.deep.equal({
+      type: 'ACTION_1',
+      payload: 1,
+      meta: { meta1: 1 }
+    });
+
+    expect(action2({ value: 2 })).to.deep.equal({
+      type: 'ACTION_2',
+      payload: { value: 2 },
+      meta: { meta2: 2 }
+    });
+  });
+
   it('should use the identity and meta creators in array form', () => {
     const { action1, action2 } = createActions({
       ACTION_1: [

--- a/src/createActions.js
+++ b/src/createActions.js
@@ -6,6 +6,7 @@ import last from 'lodash/last';
 import isString from 'lodash/isString';
 import isFunction from 'lodash/isFunction';
 import isNil from 'lodash/isNil';
+import isNull from 'lodash/isNull';
 import createAction from './createAction';
 import invariant from 'invariant';
 import arrayToObject from './arrayToObject';
@@ -44,7 +45,7 @@ function actionMapToActionCreators(actionMap) {
       return true;
     } else if (isArray(actionMapValue)) {
       const [payload = identity, meta] = actionMapValue;
-      return isFunction(payload) && isFunction(meta);
+      return (isFunction(payload) || isNull(payload)) && isFunction(meta);
     }
     return false;
   }


### PR DESCRIPTION
This PR adds `null` payload creator support in `createActions` for consistency with `createAction`.
See #239 and #169.