### PR TITLE
fix(readme): fix the typo of the getting-started link

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 [Flux Standard Action](https://github.com/acdlite/flux-standard-action) utilities for Redux.
 
 ### Table of Contents
-* [Getting Started](#gettingstarted)
+* [Getting Started](#getting-started)
   * [Installation](#installation)
   * [Usage](#usage)
 * [Documentation](#documentation)


### PR DESCRIPTION
fix the links in readme, make the `getting-started` link works well.