### PR TITLE
Curried version of createAction

### DIFF
--- a/src/createCurriedAction.js
+++ b/src/createCurriedAction.js
@@ -1,0 +1,5 @@
+import createAction from './createAction';
+import curryN from 'lodash/fp/curryN';
+
+export default (type, payloadCreator) =>
+    curryN(payloadCreator.length, createAction(type, payloadCreator));


### PR DESCRIPTION
This PR adds a curried version of `createAction` so that the payload creator can be partially applied.

This is useful when you want to bind certain parameters to the payload creator without having to create a createAction factory

For example (before and after)

```
const updateCartSize = createAction(UPDATE_CART_SIZE, (previousSize, newItemsLength) => previousSize + newItemsLength);

// We might want to bind the `previousSize` as part of `mapDispatchToProps`

const mapDispatchToProps = {
 updateCartSize: updateCartSize(currentCartSize)
}

// To do this we need to change our action creator to close over our `previousSize` value:

const updateCartSize = previousSize => createAction(UPDATE_CART_SIZE, (newItemsLength) => previousSize + newItemsLength);
```

Instead of having to that, this PR introduces a curried version of the `createAction` function that allows partial application of the payload creator parameters:

```
const updateCartSize = createCurriedAction(UPDATE_CART_SIZE, (previousSize, newItemsLength) => previousSize + newItemsLength);
```

which brings us back to our preferred API 

The example above is simplified but in our codebase this would really help us with consistency and our FP approach.

Fixes #257