### PR TITLE
Allow JavaScript Map to be used as the reducer map to handleActions

### DIFF
--- a/docs/api/handleAction.md
+++ b/docs/api/handleAction.md
@@ -114,3 +114,30 @@ const reducer = handleActions(
   { counter: 0 }
 );
 ```
+
+You can also use an action function as the key to a reduce function instead of using a string const:
+
+
+```js
+const increment = createAction(INCREMENT);
+const decrement = createAction(DECREMENT);
+
+const reducer = handleActions(
+  new Map([
+    [
+      increment,
+      (state, action) => ({
+        counter: state.counter + action.payload
+      })
+    ],
+
+    [
+      decrement,
+      (state, action) => ({
+        counter: state.counter - action.payload
+      })
+    ]
+  ]),
+  { counter: 0 }
+);
+```

--- a/docs/api/handleAction.md
+++ b/docs/api/handleAction.md
@@ -92,3 +92,25 @@ const reducer = handleActions({
   })
 }, { counter: 0 });
 ```
+Or using a JavaScript `Map` type:
+
+```js
+const reducer = handleActions(
+  new Map([
+    [
+      INCREMENT,
+      (state, action) => ({
+        counter: state.counter + action.payload
+      })
+    ],
+
+    [
+      DECREMENT,
+      (state, action) => ({
+        counter: state.counter - action.payload
+      })
+    ]
+  ]),
+  { counter: 0 }
+);
+```

--- a/src/__tests__/handleActions-test.js
+++ b/src/__tests__/handleActions-test.js
@@ -60,6 +60,36 @@ describe('handleActions', () => {
       });
   });
 
+  it('create a single handler from a JavaScript Map of multiple action handlers', () => {
+    const reducer = handleActions(
+      new Map([
+        [
+          'INCREMENT',
+          (state, action) => ({
+            counter: state.counter + action.payload
+          })
+        ],
+
+        [
+          'DECREMENT',
+          (state, action) => ({
+            counter: state.counter - action.payload
+          })
+        ]
+      ]),
+      defaultState
+    );
+
+    expect(reducer({ counter: 3 }, { type: 'INCREMENT', payload: 7 }))
+      .to.deep.equal({
+        counter: 10
+      });
+    expect(reducer({ counter: 10 }, { type: 'DECREMENT', payload: 7 }))
+      .to.deep.equal({
+        counter: 3
+      });
+  });
+
   it('works with symbol action types', () => {
     const INCREMENT = Symbol();
 

--- a/src/__tests__/handleActions-test.js
+++ b/src/__tests__/handleActions-test.js
@@ -90,6 +90,39 @@ describe('handleActions', () => {
       });
   });
 
+  it('works with function action types', () => {
+    const increment = createAction('INCREMENT');
+    const decrement = createAction('DECREMENT');
+
+    const reducer = handleActions(
+      new Map([
+        [
+          increment,
+          (state, action) => ({
+            counter: state.counter + action.payload
+          })
+        ],
+
+        [
+          decrement,
+          (state, action) => ({
+            counter: state.counter - action.payload
+          })
+        ]
+      ]),
+      defaultState
+    );
+
+    expect(reducer({ counter: 3 }, { type: 'INCREMENT', payload: 7 }))
+      .to.deep.equal({
+        counter: 10
+      });
+    expect(reducer({ counter: 10 }, { type: 'DECREMENT', payload: 7 }))
+      .to.deep.equal({
+        counter: 3
+      });
+  });
+
   it('works with symbol action types', () => {
     const INCREMENT = Symbol();
 

--- a/src/flattenUtils.js
+++ b/src/flattenUtils.js
@@ -2,8 +2,13 @@ import camelCase from './camelCase';
 import ownKeys from './ownKeys';
 import hasGeneratorInterface from './hasGeneratorInterface';
 import isPlainObject from 'lodash/isPlainObject';
+import isMap from 'lodash/isMap';
 
 const defaultNamespace = '/';
+
+function get(key, x) {
+  return isMap(x) ? x.get(key) : x[key];
+}
 
 const flattenWhenNode = predicate => function flatten(
   map,
@@ -19,12 +24,12 @@ const flattenWhenNode = predicate => function flatten(
 
   ownKeys(map).forEach(type => {
     const nextNamespace = connectNamespace(type);
-    const mapValue = map[type];
+    const mapValue = get(type, map);
 
     if (!predicate(mapValue)) {
-      partialFlatMap[nextNamespace] = map[type];
+      partialFlatMap[nextNamespace] = mapValue;
     } else {
-      flatten(map[type], namespace, partialFlatMap, nextNamespace);
+      flatten(mapValue, namespace, partialFlatMap, nextNamespace);
     }
   });
 
@@ -33,7 +38,7 @@ const flattenWhenNode = predicate => function flatten(
 
 const flattenActionMap  = flattenWhenNode(isPlainObject);
 const flattenReducerMap = flattenWhenNode(
-  node => isPlainObject(node) && !hasGeneratorInterface(node)
+  node => (isPlainObject(node) || isMap(node)) && !hasGeneratorInterface(node)
 );
 
 function unflattenActionCreators(flatActionCreators, namespace = defaultNamespace) {

--- a/src/handleActions.js
+++ b/src/handleActions.js
@@ -1,20 +1,25 @@
 import isPlainObject from 'lodash/isPlainObject';
+import isMap from 'lodash/isMap';
 import reduceReducers from 'reduce-reducers';
 import invariant from 'invariant';
 import handleAction from './handleAction';
 import ownKeys from './ownKeys';
 import { flattenReducerMap } from './flattenUtils';
 
+function get(key, x) {
+  return isMap(x) ? x.get(key) : x[key];
+}
+
 export default function handleActions(handlers, defaultState, { namespace } = {}) {
   invariant(
-    isPlainObject(handlers),
+    isPlainObject(handlers) || isMap(handlers),
     'Expected handlers to be a plain object.'
   );
   const flattenedReducerMap = flattenReducerMap(handlers, namespace);
   const reducers = ownKeys(flattenedReducerMap).map(type =>
     handleAction(
       type,
-      flattenedReducerMap[type],
+      get(type, flattenedReducerMap),
       defaultState
     )
   );

--- a/src/ownKeys.js
+++ b/src/ownKeys.js
@@ -1,4 +1,11 @@
+import isMap from 'lodash/isMap';
+
 export default function ownKeys(object) {
+
+  if (isMap(object)) {
+    return Array.from(object.keys());
+  }
+
   if (typeof Reflect !== 'undefined' && typeof Reflect.ownKeys === 'function') {
     return Reflect.ownKeys(object);
   }


### PR DESCRIPTION
**What**

Allow JavaScript `Map` type to be used as the `map` value to `handleActions`

**Why**

`handleActions` allows you to give it a function created with `createAction` as the key to a reducer. JavaScript doesn't allow functions to be object keys (strings only) but `Map` lets us use any value as the keys

## Implementation
- [x] Add support for JavaScript `Map` as the map parameter to `handleActions`

## Documentation
- [x] Add documentation for using a JavaScript `Map` as the map parameter to `handleActions`
- [x] Add documentation for using a function as the key to a JavaScript map for `handleActions`

## Tests
- [x] Add a test to assert that `handleActions` works correctly given a JavaScript `Map`
- [x] Add a test to assert that functions  work as map keys in `handleActions`

Fixes #267 